### PR TITLE
Fix duplicate 'draft' key in front matter

### DIFF
--- a/content/posts/2017-03-06-ms3-serial-adapter.md
+++ b/content/posts/2017-03-06-ms3-serial-adapter.md
@@ -7,7 +7,6 @@ tags:
 - factorytech
 - barcodes
 title: MS3 Adapter for Serial Port and Power
-draft: false
 ---
 
 In last week's post 


### PR DESCRIPTION
Remove duplicate 'draft: false' entry that was causing Hugo build failure
with error: mapping key "draft" already defined